### PR TITLE
Remove iOS6 deprecated warnings

### DIFF
--- a/src/NSBubbleData.m
+++ b/src/NSBubbleData.m
@@ -54,11 +54,11 @@ const UIEdgeInsets textInsetsSomeone = {5, 15, 11, 10};
 - (id)initWithText:(NSString *)text date:(NSDate *)date type:(NSBubbleType)type
 {
     UIFont *font = [UIFont systemFontOfSize:[UIFont systemFontSize]];
-    CGSize size = [(text ? text : @"") sizeWithFont:font constrainedToSize:CGSizeMake(220, 9999) lineBreakMode:UILineBreakModeWordWrap];
+    CGSize size = [(text ? text : @"") sizeWithFont:font constrainedToSize:CGSizeMake(220, 9999) lineBreakMode:NSLineBreakByWordWrapping];
     
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, size.width, size.height)];
     label.numberOfLines = 0;
-    label.lineBreakMode = UILineBreakModeWordWrap;
+    label.lineBreakMode = NSLineBreakByWordWrapping;
     label.text = (text ? text : @"");
     label.font = font;
     label.backgroundColor = [UIColor clearColor];

--- a/src/UIBubbleHeaderTableViewCell.m
+++ b/src/UIBubbleHeaderTableViewCell.m
@@ -42,7 +42,7 @@
     self.label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, [UIBubbleHeaderTableViewCell height])];
     self.label.text = text;
     self.label.font = [UIFont boldSystemFontOfSize:12];
-    self.label.textAlignment = UITextAlignmentCenter;
+    self.label.textAlignment = NSTextAlignmentCenter;
     self.label.shadowOffset = CGSizeMake(0, 1);
     self.label.shadowColor = [UIColor whiteColor];
     self.label.textColor = [UIColor darkGrayColor];


### PR DESCRIPTION
UITextAlignmentCenter and UILineBreakModeWordWrap is deprecated: first deprecated in iOS 6.0
