### PR TITLE
Autoscroll added, automatically moves to bottom of chat UIBubbleTableView when reloadData is called.

### DIFF
--- a/src/UIBubbleTableView.h
+++ b/src/UIBubbleTableView.h
@@ -27,4 +27,6 @@ typedef enum _NSBubbleTypingType
 @property (nonatomic) NSBubbleTypingType typingBubble;
 @property (nonatomic) BOOL showAvatars;
 
+- (BOOL) scrollToBottomWithAnimation:(BOOL)animatedBool;
+
 @end

--- a/src/UIBubbleTableView.m
+++ b/src/UIBubbleTableView.m
@@ -149,17 +149,22 @@
     
     [super reloadData];
     
-	[self scrollToBottom];
+	[self scrollToBottomWithAnimation:YES];
 }
 
-- (void) scrollToBottom {
-	
-    //Autoscroll to bottom of chat when reloadData called
+- (BOOL) scrollToBottomWithAnimation:(BOOL)animatedBool {
+	//Autoscroll to bottom of chat when reloadData called. Returns whether scroll actually occurred.
+
     int sectionCount = [self numberOfSections];
+
+    if(sectionCount<=0) return NO;
+
     int rowsInLastSection = [self numberOfRowsInSection:sectionCount-1];
     
     NSIndexPath *scrollIndexPath = [NSIndexPath indexPathForRow:rowsInLastSection-1 inSection:sectionCount-1];
-    [self scrollToRowAtIndexPath:scrollIndexPath atScrollPosition:UITableViewScrollPositionBottom animated:YES];	
+    [self scrollToRowAtIndexPath:scrollIndexPath atScrollPosition:UITableViewScrollPositionBottom animated:animatedBool];
+
+    return YES;	
 	
 }
 

--- a/src/UIBubbleTableView.m
+++ b/src/UIBubbleTableView.m
@@ -148,6 +148,13 @@
     }
     
     [super reloadData];
+    
+    //Autoscroll to bottom of chat when reloadData called
+    int sectionCount = [self numberOfSections];
+    int rowsInLastSection = [self numberOfRowsInSection:sectionCount-1];
+    
+    NSIndexPath *scrollIndexPath = [NSIndexPath indexPathForRow:rowsInLastSection-1 inSection:sectionCount-1];
+    [self scrollToRowAtIndexPath:scrollIndexPath atScrollPosition:UITableViewScrollPositionBottom animated:YES];
 }
 
 #pragma mark - UITableViewDelegate implementation

--- a/src/UIBubbleTableView.m
+++ b/src/UIBubbleTableView.m
@@ -149,12 +149,18 @@
     
     [super reloadData];
     
+	[self scrollToBottom];
+}
+
+- (void) scrollToBottom {
+	
     //Autoscroll to bottom of chat when reloadData called
     int sectionCount = [self numberOfSections];
     int rowsInLastSection = [self numberOfRowsInSection:sectionCount-1];
     
     NSIndexPath *scrollIndexPath = [NSIndexPath indexPathForRow:rowsInLastSection-1 inSection:sectionCount-1];
-    [self scrollToRowAtIndexPath:scrollIndexPath atScrollPosition:UITableViewScrollPositionBottom animated:YES];
+    [self scrollToRowAtIndexPath:scrollIndexPath atScrollPosition:UITableViewScrollPositionBottom animated:YES];	
+	
 }
 
 #pragma mark - UITableViewDelegate implementation


### PR DESCRIPTION
For me, I wanted my chat to scroll to bottom on arrival of a new message. Conveniently, this is when reloadData is called, so until a developer options list is made available, this seems like a great solution for most use cases.

If this would be better served as an optional parameter, I can code it up, just let me know.

EDIT: I refactored this code out as a scrollToBottom instance method. This could make sense as a function left accessible for the user so they can call it as needed, instead of building an autoscroll option or forcing it on people using the library. Just an idea. For now, left in reloadData method to act as autoscroll.

EDIT2: For my own application, I needed a place without animation during scrolling, so I extended this method to scrollToBottomWithAnimation:(BOOL)animated. I then put this in the header as an accessible method for the rest of my controllers. If this seems useful, let me know, I will submit a separate pull request.

EDIT3: I added the optional animation code and added method prototype to header. Let me know if this is not the route you want to take with the project.
